### PR TITLE
Add synthetics approvers and maintainers as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # below groups will be requested for
 # review when someone opens a pull request.
 
-* @splunk/o11y-synthetics-admins @splunk/o11y-synthetics-approvers @splunk/o11y-synthetics-maintainers
+* @splunk/o11y-synthetics-approvers @splunk/o11y-synthetics-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # below groups will be requested for
 # review when someone opens a pull request.
 
-*  @splunk/o11y-synthetics-approvers @splunk/o11y-synthetics-maintainers
+* @splunk/o11y-synthetics-admins @splunk/o11y-synthetics-approvers @splunk/o11y-synthetics-maintainers


### PR DESCRIPTION
## Summary

- Extend the existing `.github/CODEOWNERS` wildcard rule to include the approvers and maintainers team
- Preserve the existing approvers and maintainers ownership.

## Why

This aligns repository-wide ownership with the other synthetics repositories and lets GitHub request two synthetics teams when pull requests change any file.

## Impact

All paths continue to match the wildcard ownership rule, now with  approvers and maintainers. This is repository configuration only and does not change chart behavior.

## Validation

- Confirmed the branch differs from `main` by only `.github/CODEOWNERS`.
- Confirmed the wildcard rule contains `@splunk/o11y-synthetics-approvers`, and `@splunk/o11y-synthetics-maintainers`.