### PR TITLE
ci: pin Helm 3 toolchain

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,8 +21,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up latest stable version of Helm
+      - name: Set up Helm 3.21.3
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        with:
+          version: v3.21.3
 
       - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
@@ -57,8 +59,8 @@ jobs:
 
       - name: Run helm unit tests
         run: |
-          echo "Installing latest version of helm unittest plugin..."
-          helm plugin install https://github.com/helm-unittest/helm-unittest >/dev/null 2>/dev/null
+          echo "Installing helm unittest plugin v1.1.2..."
+          helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.2
           make unittest
 
       - name: Create kind cluster


### PR DESCRIPTION
## Summary

- Pin Helm to `v3.21.3` instead of resolving the latest stable release.
- Pin the `helm-unittest` plugin to `v1.1.2`.
- Preserve plugin installation output so future installation failures are visible in Actions logs.

## Root cause

The `Lint and Test` workflow did not provide a `version` to `azure/setup-helm`, so the action began installing Helm `v4.2.3` when Helm 4 became the latest stable release. The repository's existing plugin installation and unit-test commands are Helm 3-oriented.

The failure occurred before tests ran while installing `helm-unittest`:

```text
Error: plugin source does not support verification. Use --verify=false to skip verification
```

The workflow redirected both stdout and stderr from that command, which hid this diagnostic in the original job output. Adding `--verify=false` alone is not sufficient: with Helm 4, the existing `helm unittest --color --strict ...` command treats `--color` as a Helm global option and consumes `--strict` as its value.

This is toolchain version drift and is unrelated to the CODEOWNERS-only change in #59.

Failed job: https://github.com/splunk/synthetics-helm-charts/actions/runs/30307093308/job/90113860627

## Why Helm 3 is pinned instead of resolved dynamically

`azure/setup-helm` supports either the overall latest stable Helm release or an exact semantic version; it does not provide a selector for the latest Helm 3 release. A separate step could query `https://get.helm.sh/helm3-latest-version`, but that approach was not selected because:

- A new Helm 3 minor or patch could change CI behavior without any repository change or review.
- Re-running the same commit at different times could use different Helm binaries, making failures harder to reproduce.
- The additional network lookup introduces another external dependency and failure point.
- An exact version lets Helm upgrades be reviewed and validated deliberately. Dependency automation can propose future version bumps without sacrificing reproducibility.

The exact pin prevents another unreviewed major-version transition while keeping the toolchain used by this repository explicit.

## Validation

Validated locally with the exact versions and commands introduced here:

```text
Helm: v3.21.3+g1ad6e68
helm-unittest: 1.1.2
Charts:      1 passed, 1 total
Test Suites: 6 passed, 6 total
Tests:       29 passed, 29 total
Snapshot:    0 passed, 0 total
```

Also ran `git diff --check` successfully. The validation left no generated or untracked repository changes.
